### PR TITLE
add -u and -g options for  mapped (u/g)id

### DIFF
--- a/src/vpnns.c
+++ b/src/vpnns.c
@@ -477,6 +477,8 @@ static int connect_to_watcher(const char *statedir)
 	return fd;
 }
 
+static uid_t muid = 0, mgid = 0;
+
 static int create_ns(const char *statedir, const char *name)
 {
 	char str[64];
@@ -489,9 +491,9 @@ static int create_ns(const char *statedir, const char *name)
 
 	if (access("/proc/self/setgroups", O_RDONLY) == 0)
 		write_file("/proc/self/setgroups", "deny");
-	snprintf(str, sizeof(str), "0 %d 1", uid);
+	snprintf(str, sizeof(str), "%d %d 1", muid, uid);
 	write_file("/proc/self/uid_map", str);
-	snprintf(str, sizeof(str), "0 %d 1", gid);
+	snprintf(str, sizeof(str), "%d %d 1", mgid, gid);
 	write_file("/proc/self/gid_map", str);
 
 	if (sethostname(name, strlen(name)) < 0)
@@ -803,6 +805,8 @@ static struct option longopts[] = {
 	{ "script",		1,	NULL,	's' },
 	{ "help",		0,	NULL,	'h' },
 	{ "version",		0,	NULL,	'v' },
+	{ "uid",                1,      NULL,   'u' },
+	{ "gid",                1,      NULL,   'g' },
 	{ NULL }
 };
 
@@ -828,6 +832,12 @@ int main(int argc, char **argv)
 			break;
 		case 's':
 			script = optarg;
+			break;
+		case 'u':
+			muid = (uid_t) strtol(optarg, (char**) NULL, 10);
+			break;
+		case 'g':
+			mgid = (uid_t) strtol(optarg, (char**) NULL, 10);
 			break;
 		case 'h':
 		case '?':


### PR DESCRIPTION
Allows user to specify the in-container uid and gid to be mapped to (most often their own), instead of (virtual) root.

Typical invokation

```sh
vpnns --uid 1000 --gid 1000 --attach
```