### PR TITLE
deactivate nscd in container

### DIFF
--- a/src/vpnns.c
+++ b/src/vpnns.c
@@ -498,6 +498,12 @@ static int create_ns(const char *statedir, const char *name)
 		pdie("can't set hostname");
 	setup_ipv4("lo", "127.0.0.1", "255.0.0.0", false, 0);
 
+        // disable nscd
+
+        mount("empty", "/var/run/nscd", "tmpfs", 0, "");
+
+        // overlay /etc
+
 	mkdir(statedir, 0755);
 	char *local_etc = populate_statedir(statedir, "etc", true);
 	char *workdir = populate_statedir(statedir, "workdir", true);


### PR DESCRIPTION
For VPNs that come with their own DNS service, nscd can throw a spanner into the works of `vpnns`, because programs access `nscd` via its file socket in `/var/run`.

This patch has been tested with a single system and it's probably not correct for systems that have no nscd, or have its socket file at a different location.

Nevertheless, it fixes my vpn, so I'll leave it here as a data point.